### PR TITLE
Avoid trice uri encode

### DIFF
--- a/assets/js/kv-tree.js
+++ b/assets/js/kv-tree.js
@@ -153,7 +153,7 @@
             var self = this, $detail = self.$detail, parent = par || '', msg = mesg || false,
                 params = hashString(key + self.modelClass + self.isAdmin + parent),
                 vUrl = self.actions.manage, sep = vUrl && vUrl.indexOf('?') !== -1 ? '&' : '?';
-            vUrl = encodeURI(vUrl + sep + 'q=' + params);
+            vUrl += encodeURI(sep + 'q=' + params);
             self.parseCache();
             $.ajax({
                 type: 'post',


### PR DESCRIPTION
When I try click add new root, request go to url 
/index.php?r=treemanager%252Fnode%252Fmanage&q=1292103820
but must go to 
/index.php?r=treemanager%2Fnode%2Fmanage&q=1292103820

It's because here vUrl also encoded, I hope that this commit fix this problem in rigth way.

Thank you very muck for this great yii2 extension, it's so nice!

Sorry for my english