### PR TITLE
Expose ajax settings from request in events

### DIFF
--- a/assets/js/kv-tree.js
+++ b/assets/js/kv-tree.js
@@ -189,8 +189,8 @@
                 },
                 url: vUrl,
                 cache: true,
-                beforeSend: function (jqXHR) {
-                    self.raise('treeview.beforeselect', [key, jqXHR]);
+                beforeSend: function (jqXHR, settings) {
+                    self.raise('treeview.beforeselect', [key, jqXHR, settings]);
                     if ($form.length) {
                         $form.off().yiiActiveForm('destroy').remove();
                     }
@@ -314,8 +314,8 @@
                         'softDelete': self.softDelete
                     },
                     url: self.actions.remove,
-                    beforeSend: function (jqXHR) {
-                        self.raise('treeview.beforeremove', [key, jqXHR]);
+                    beforeSend: function (jqXHR, settings) {
+                        self.raise('treeview.beforeremove', [key, jqXHR, settings]);
                         $form.hide();
                         self.removeAlert();
                         addCss($detail, 'kv-loading');
@@ -413,8 +413,8 @@
                     'allowNewRoots': self.allowNewRoots
                 },
                 url: self.actions.move,
-                beforeSend: function (jqXHR) {
-                    self.raise('treeview.beforemove', [dir, keyFrom, keyTo, jqXHR]);
+                beforeSend: function (jqXHR, settings) {
+                    self.raise('treeview.beforemove', [dir, keyFrom, keyTo, jqXHR, settings]);
                     addCss(self.$treeContainer, 'kv-loading-search');
                 },
                 success: function (data, textStatus, jqXHR) {


### PR DESCRIPTION
This makes it possible to extend the data send to the server. This is useful for example when extending the included node controller and implementing own $_POST checks for conditional views, but keeping the basics.

Minified js version not provided here.

Needed updates in documentation:
http://demos.krajee.com/tree-manager#event-treeview-beforeremove
http://demos.krajee.com/tree-manager#event-treeview-beforeselect
http://demos.krajee.com/tree-manager#event-treeview-beforemove