### PR TITLE
close tree input widget after you've selected a node

### DIFF
--- a/assets/js/kv-tree-input.js
+++ b/assets/js/kv-tree-input.js
@@ -69,6 +69,7 @@
             });
             self.$element.on('treeview.change', function (event, keys, desc) {
                 self.setInput(desc.split(','));
+                self.$input.parent('div').removeClass('open');
             });
         }
     };

--- a/assets/js/kv-tree.js
+++ b/assets/js/kv-tree.js
@@ -815,9 +815,8 @@
                 addCss($node, 'kv-selected');
                 self.check($node);
             }
-        },
-    }
-    ;
+        }
+    };
 
     $.fn.treeview = function (option) {
         var args = Array.apply(null, arguments), $this, data, options;


### PR DESCRIPTION
and cleanup unnecessary comma