### PR TITLE
Show attribute data-krajee-treeinput

### DIFF
--- a/TreeViewInput.php
+++ b/TreeViewInput.php
@@ -126,8 +126,8 @@ class TreeViewInput extends TreeView
         if ($this->asDropdown) {
             $this->initDropdown();
         }
-        parent::run();
         $this->registerInputAssets();
+        parent::run();
     }
 
     /**


### PR DESCRIPTION
Method `TreeViewInput::registerInputAssets()` have line
```
$this->options['data-krajee-' . $name] = $var;
```
But we can't see this attribute, because widget are rendering earlier.