### PR TITLE
Add option to select only leaves

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,5 +1,10 @@
 Change Log: `yii2-tree-manager`
 ===============================
+## Version 1.1.2
+
+**Date:** 02-Feb-2019
+
+- New boolean property `restrictSelectToLeaves` to restrict nodes selection to leaves on TreeViewInput.
 
 ## Version 1.1.1
 

--- a/src/TreeView.php
+++ b/src/TreeView.php
@@ -241,6 +241,8 @@ class TreeView extends Widget
      */
     public $cascadeSelectChildren = true;
 
+    public $allowSelectOnlyLeaves = false;
+
     /**
      * @var integer animation duration (ms) for fading in and out alerts that are displayed during manipulation of nodes.
      */

--- a/src/TreeView.php
+++ b/src/TreeView.php
@@ -241,7 +241,10 @@ class TreeView extends Widget
      */
     public $cascadeSelectChildren = true;
 
-    public $allowSelectOnlyLeaves = false;
+    /**
+     * @var boolean whether to restrict the select to the leaves of the tree.
+     */
+    public $restrictSelectToLeaves = false;
 
     /**
      * @var integer animation duration (ms) for fading in and out alerts that are displayed during manipulation of nodes.
@@ -1286,6 +1289,7 @@ HTML;
             'breadcrumbs' => $this->breadcrumbs,
             'multiple' => $this->multiple,
             'cascadeSelectChildren' => $this->cascadeSelectChildren,
+            'restrictSelectToLeaves' => $this->restrictSelectToLeaves,
             'allowNewRoots' => $this->allowNewRoots,
             'hideUnmatchedSearchItems' => $this->hideUnmatchedSearchItems
         ];

--- a/src/assets/js/kv-tree.js
+++ b/src/assets/js/kv-tree.js
@@ -709,6 +709,9 @@
             if ($node.hasClass('kv-disabled') || (isRoot && !isMultiple)) {
                 return;
             }
+            if ($node.hasClass('kv-parent') && self.restrictSelectToLeaves) {
+                return;
+            }
             if ($node.hasClass('kv-selected')) {
                 if (!self.raise('treeview.unchecked', [nodeKey])) {
                     return;
@@ -1024,6 +1027,7 @@
         },
         breadcrumbs: {},
         cascadeSelectChildren: true,
+        restrictSelectToLeaves: false,
         rootKey: '',
         hideUnmatchedSearchItems: true
     };


### PR DESCRIPTION
## Scope
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-tree-manager/blob/master/CHANGE.md)):

- New boolean property `restrictSelectToLeaves` to restrict nodes selection to leaves on TreeViewInput.

## Related Issues
If this is related to an existing ticket, include a link to it as well.