### PR TITLE
Don't double encode Names

### DIFF
--- a/src/models/TreeTrait.php
+++ b/src/models/TreeTrait.php
@@ -125,7 +125,7 @@ trait TreeTrait
                 $nameAttribute,
                 'filter',
                 'filter' => function ($value) {
-                    return Html::encode($value);
+                    return Html::encode($value,false);
                 },
             ];
         }


### PR DESCRIPTION
## Scope
This pull request includes a

- [ x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-tree-manager/blob/master/CHANGE.md)):

- Added false argument to Html::encode in TreeTrait
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.
https://github.com/kartik-v/yii2-tree-manager/issues/254