### PR TITLE
Update Module url route validation only for web apps

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -124,12 +124,15 @@ class Module extends \kartik\base\Module
             'iconTypeAttribute' => 'icon_type'
         ];
         $nodeActions = ArrayHelper::getValue($this->treeViewSettings, 'nodeActions', []);
-        $nodeActions += [
-            self::NODE_MANAGE => Url::to(['/treemanager/node/manage']),
-            self::NODE_SAVE => Url::to(['/treemanager/node/save']),
-            self::NODE_REMOVE => Url::to(['/treemanager/node/remove']),
-            self::NODE_MOVE => Url::to(['/treemanager/node/move']),
-        ];
+        // prepends Error in Console Applications
+        if (\Yii::$app instanceof \yii\web\Application) {
+            $nodeActions += [
+                self::NODE_MANAGE => Url::to(['/treemanager/node/manage']),
+                self::NODE_SAVE => Url::to(['/treemanager/node/save']),
+                self::NODE_REMOVE => Url::to(['/treemanager/node/remove']),
+                self::NODE_MOVE => Url::to(['/treemanager/node/move']),
+            ];
+        }
         $this->treeViewSettings['nodeActions'] = $nodeActions;
     }
 }


### PR DESCRIPTION
To avoid Errors in Console-Applications, by using the extension, do not generate urls, that cause error!

## Scope
This pull request includes a

- [x ] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-tree-manager/blob/master/CHANGE.md)):

- when using this plugin, a console command cause an error, by generation url, because definition of url-constants in init-command cannot be resolved.
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.