### PR TITLE
Update kv-tree-input.js

### DIFF
--- a/src/assets/js/kv-tree-input.js
+++ b/src/assets/js/kv-tree-input.js
@@ -76,7 +76,7 @@
             self.$element.on('treeview:change', function (event, keys, desc) {
                 self.setInput(desc.split(','));
                 if (self.autoCloseOnSelect) {
-                    self.$input.closest('.kv-tree-dropdown-container').removeClass('open');
+                    self.$dropdown.removeClass('show');
                 }
             });
         }


### PR DESCRIPTION
fix autoCloseOnSelect not working correct

## Scope
This pull request includes a

- [x] Bug fix

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-tree-manager/blob/master/CHANGE.md)):

-self.$input.closest('.kv-tree-dropdown-container').removeClass('open'); => self.$dropdown.removeClass('show');
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.